### PR TITLE
Refine output hook ordering and UI behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,8 +77,8 @@
 
       <div class="quick-actions">
         <button id="btn-copy-all" class="btn">Copy All</button>
-        <button id="btn-copy-chorus" class="btn">Copy Chorus</button>
-        <button id="btn-copy-hook" class="btn">Copy Hook</button>
+        <button id="btn-copy-chorus" class="btn" disabled>Copy Chorus</button>
+        <button id="btn-copy-hook" class="btn" disabled>Copy Hook</button>
         <button id="btn-copy-captions" class="btn">Copy Captions</button>
         <button id="btn-export" class="btn">Export .txt</button>
         <button id="btn-save-notes" class="btn">Save Notes</button>

--- a/presets.js
+++ b/presets.js
@@ -45,7 +45,7 @@ No extra sections. No explanations.`,
 
     TITLE: `Return ONLY a 2–4 word title; no colons/parentheses; PG-13; punchy.
 
-[Title] Your Title]`,
+[Title] Your Title`,
 
     ADD_VERSE: `You are expanding an existing song. Add exactly one [Verse] matching the given lyrics’ meter/rhyme/tone. Do not modify existing text.
 Output only the new [Verse].`,


### PR DESCRIPTION
## Summary
- Patch `setOutput` before modal logic and disable copy buttons when sections missing
- Pull batch size from user settings and support multi-word tags
- Fix title preset formatting and initialize copy buttons as disabled

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`
- `node --check presets.js`

------
https://chatgpt.com/codex/tasks/task_e_68baf42db458832ab5dde1476e034703