### PR TITLE
Improve PWA metadata and responsive layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Hook Mill</title>
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <link rel="manifest" href="manifest.webmanifest">
+  <meta name="theme-color" content="#0c0d10">
   <link rel="stylesheet" href="styles.css">
   <meta name="description" content="Hook Mill - generate catchy song hooks quickly">
 </head>
@@ -112,7 +114,7 @@
 
   <!-- Settings Drawer -->
   <div id="settings-overlay" class="overlay" hidden></div>
-  <aside id="settings-drawer" class="settings" aria-labelledby="settings-title" hidden>
+  <aside id="settings-drawer" class="settings" aria-labelledby="settings-title" role="dialog" aria-modal="true" hidden>
     <header class="settings-header">
       <h2 id="settings-title">Settings</h2>
     </header>

--- a/styles.css
+++ b/styles.css
@@ -53,7 +53,7 @@ button:disabled{opacity:.5;cursor:not-allowed;box-shadow:var(--shadow);}
   background:var(--panel);box-shadow:var(--shadow);position:sticky;top:0;z-index:2;
 }
 .branding{display:flex;gap:0.5rem;align-items:center;}
-.logo{width:24px;height:24px;}
+.logo{width:1.5rem;height:1.5rem;}
 .header-actions{display:flex;gap:0.5rem;align-items:center;}
 .btn{
   background:var(--panel);border:1px solid rgba(255,255,255,0.08);color:var(--text);
@@ -76,7 +76,11 @@ button:disabled{opacity:.5;cursor:not-allowed;box-shadow:var(--shadow);}
 .conn-dot{width:10px;height:10px;border-radius:50%;display:inline-block;background:#555;border:1px solid #333;}
 .conn-ok{background:var(--good);} .conn-warn{background:var(--warn);} .conn-bad{background:var(--danger);}
 .main-grid{
-  display:grid;grid-template-columns:minmax(0,420px) 1fr;gap:1rem;padding:1rem;align-items:start;
+  display:grid;
+  grid-template-columns:clamp(18.75rem,40vw,26.25rem) 1fr;
+  gap:1rem;
+  padding:1rem;
+  align-items:start;
 }
 .compose,.output,.library,.settings,.modal{
   background:var(--panel);border:1px solid rgba(255,255,255,0.08);border-radius:var(--radius);
@@ -97,8 +101,14 @@ button:disabled{opacity:.5;cursor:not-allowed;box-shadow:var(--shadow);}
 .compose-actions{display:flex;gap:0.5rem;margin:0.5rem 0;}
 .status-line{display:flex;gap:0.75rem;color:var(--muted);font-size:0.75rem;margin-top:0.5rem;}
 .output{padding:1rem;}
-.output-scroller{height:420px;overflow:auto;border:1px solid rgba(255,255,255,0.08);border-radius:var(--radius-sm);
-  background:var(--bg);padding:0.625rem;box-shadow:var(--shadow);
+.output-scroller{
+  height:min(26.25rem,60vh);
+  overflow:auto;
+  border:1px solid rgba(255,255,255,0.08);
+  border-radius:var(--radius-sm);
+  background:var(--bg);
+  padding:0.625rem;
+  box-shadow:var(--shadow);
 }
 .out-view{margin:0;white-space:pre-wrap;font-family:var(--mono);line-height:1.45;}
 #out-plain{width:100%;height:100%;background:transparent;border:0;color:var(--text);}
@@ -111,19 +121,25 @@ button:disabled{opacity:.5;cursor:not-allowed;box-shadow:var(--shadow);}
   padding:0.5rem;font-size:0.9rem;box-shadow:var(--shadow);
 }
 .inline{display:flex;gap:0.625rem;align-items:center;flex-wrap:wrap;}
-.lib-list{list-style:none;padding:0;margin:0;display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:0.75rem;}
+.lib-list{list-style:none;padding:0;margin:0;display:grid;grid-template-columns:repeat(auto-fill,minmax(20rem,1fr));gap:0.75rem;}
 .lib-card{padding:0.625rem;border-radius:var(--radius-sm);border:1px solid rgba(255,255,255,0.08);background:var(--bg);box-shadow:var(--shadow);}
 .lib-card-head{display:flex;justify-content:space-between;align-items:start;margin-bottom:0.375rem;}
 .lib-title{font-weight:600;margin-bottom:0.25rem;max-width:36ch;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
 .lib-meta{display:flex;gap:0.375rem;align-items:center;color:var(--muted);font-size:0.75rem;}
 .star{border:0;background:transparent;color:#f7d26a;font-size:1.125rem;cursor:pointer;}
-.lib-output{max-height:180px;overflow:auto;background:var(--bg-alt);border:1px solid rgba(255,255,255,0.08);border-radius:var(--radius-sm);
-  padding:0.5rem;font-family:var(--mono);}
+.lib-output{
+  max-height:11.25rem;
+  overflow:auto;
+  background:var(--bg-alt);
+  border:1px solid rgba(255,255,255,0.08);
+  border-radius:var(--radius-sm);
+  padding:0.5rem;
+  font-family:var(--mono);
+}
 .lib-tags{margin-top:0.375rem;}
 .tag-editor{width:100%;background:var(--bg-alt);border:1px dashed var(--muted);color:var(--text);border-radius:var(--radius-sm);
   padding:0.375rem;font-size:0.8rem;}
 .lib-actions{display:flex;gap:0.375rem;flex-wrap:wrap;margin-top:0.5rem;}
-.lib-actions .btn-danger{background:var(--danger);border-color:var(--danger);color:#fff;}
 .settings{position:fixed;top:0;right:0;width:380px;height:100%;display:flex;flex-direction:column;}
 .settings-header{padding:0.75rem 1rem;border-bottom:1px solid rgba(0,0,0,0.2);}
 .settings-body{padding:0.75rem 1rem;display:flex;flex-direction:column;gap:0.625rem;}
@@ -147,7 +163,7 @@ button:disabled{opacity:.5;cursor:not-allowed;box-shadow:var(--shadow);}
 .modal-header,.modal-footer{padding:0.625rem 0.75rem;border-bottom:1px solid rgba(255,255,255,0.08);}
 .modal-footer{border-top:1px solid rgba(255,255,255,0.08);border-bottom:0;display:flex;gap:0.5rem;justify-content:flex-end;}
 .modal-body{padding:0.625rem 0.75rem;}
-.mini-stream{min-height:220px;max-height:420px;overflow:auto;background:var(--bg-alt);border:1px solid rgba(255,255,255,0.08);
+.mini-stream{min-height:13.75rem;max-height:26.25rem;overflow:auto;background:var(--bg-alt);border:1px solid rgba(255,255,255,0.08);
   border-radius:var(--radius-sm);padding:0.5rem;font-family:var(--mono);}
 .toasts{position:fixed;bottom:1rem;right:1rem;display:flex;flex-direction:column;gap:0.5rem;z-index:5;}
 .toast{background:var(--panel);border:1px solid rgba(255,255,255,0.08);color:var(--text);padding:0.5rem 0.625rem;
@@ -160,16 +176,15 @@ button:disabled{opacity:.5;cursor:not-allowed;box-shadow:var(--shadow);}
   .compose{position:static;}
 }
 
-.install-banner{position:fixed;bottom:0;left:0;right:0;display:flex;align-items:center;justify-content:space-between;padding:10px;background:var(--panel);border-top:1px solid #22283a;z-index:5}
+.install-banner{position:fixed;bottom:0;left:0;right:0;display:flex;align-items:center;justify-content:space-between;padding:0.625rem;background:var(--panel);border-top:1px solid #22283a;z-index:5}
 .install-banner[hidden]{display:none}
-.install-actions{display:flex;gap:8px}
+.install-actions{display:flex;gap:0.5rem}
 
 
 /* Mobile tweaks */
 @media (max-width:600px){
   .app-header{flex-wrap:wrap;gap:0.5rem;}
   .header-actions{flex-wrap:wrap;justify-content:center;}
-  .output-scroller{height:60vh;}
   .library-filters{flex-direction:column;align-items:stretch;}
   .settings{width:100%;}
 }


### PR DESCRIPTION
## Summary
- add web manifest and theme color for PWA support
- make settings drawer accessible and refine responsive layout
- replace fixed pixel sizes with flexible rem/clamp values and remove duplicate styles

## Testing
- `npx --yes htmlhint index.html`
- `npx --yes csslint styles.css` *(fails: csslint does not understand modern CSS variables; 195 warnings remain)*
- `npx --yes eslint app.js` *(fails: ESLint configuration file missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2d25eeb0832a807dd724a41d8f85