### PR TITLE
Fix service worker caching and settings drawer close behavior

### DIFF
--- a/app.js
+++ b/app.js
@@ -681,20 +681,27 @@
   });
 
   // Settings open/close
-  $('#btn-settings').onclick = ()=>{
+  // Settings drawer open/close
+  $('#btn-settings').addEventListener('click', () => {
     $('#settings-overlay').hidden = false;
     $('#settings-drawer').hidden = false;
     $('#btn-settings').setAttribute('aria-expanded', 'true');
     Settings.load();
-  };
-  $('#btn-close-settings').onclick = closeSettings;
-  $('#settings-overlay').onclick = closeSettings;
+  });
+
+  $('#btn-close-settings').addEventListener('click', closeSettings);
+  $('#settings-overlay').addEventListener('click', closeSettings);
+
   function closeSettings(){
     $('#settings-overlay').hidden = true;
     $('#settings-drawer').hidden = true;
     $('#btn-settings').setAttribute('aria-expanded','false');
   }
-  $('#btn-save-settings').onclick = ()=>Settings.save();
+
+  $('#btn-save-settings').addEventListener('click', () => {
+    Settings.save();
+    closeSettings();
+  });
   $('#btn-clear-data').onclick = async ()=>{
     if (!confirm('Clear ALL data (settings + library)?')) return;
     await HookMillDB.clearAll();


### PR DESCRIPTION
## Summary
- Prevent service worker install failures by caching assets individually and using relative paths
- Ensure settings drawer can be closed and closes after saving

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc35da2a64832aba03ef8b6f76b06c