### PR TITLE
fix: allow settings menu to close

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -141,7 +141,7 @@ button:disabled{opacity:.5;cursor:not-allowed;box-shadow:var(--shadow);}
 .tag-editor{width:100%;background:var(--bg-alt);border:1px dashed var(--muted);color:var(--text);border-radius:var(--radius);
   padding:0.375rem;font-size:0.8rem;}
 .lib-actions{display:flex;gap:0.375rem;flex-wrap:wrap;margin-top:0.5rem;}
-.settings{position:fixed;top:0;right:0;width:380px;height:100%;display:flex;flex-direction:column;}
+.settings{position:fixed;top:0;right:0;width:380px;height:100%;display:flex;flex-direction:column;z-index:4;}
 .settings-header{padding:0.75rem 1rem;border-bottom:1px solid rgba(0,0,0,0.2);}
 .settings-body{padding:0.75rem 1rem;display:flex;flex-direction:column;gap:0.625rem;}
 .settings input[type="text"], .settings input[type="password"]{width:100%;background:var(--bg);border:1px solid rgba(255,255,255,0.12);


### PR DESCRIPTION
## Summary
- Ensure settings drawer appears above overlay so its close controls are clickable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc39267184832ab378610354275f96